### PR TITLE
Add upsert() method for Bulk.find

### DIFF
--- a/lib/bulk.js
+++ b/lib/bulk.js
@@ -13,8 +13,8 @@ var Bulk = function(colName, ordered, onserver, dbname) {
 
   var self = this;
   this.find = function(query) {
+    var upsert = false;
     var findobj = {};
-
     var remove = function(lim) {
       if (!self._currCmd) {
         self._currCmd = {
@@ -54,7 +54,11 @@ var Bulk = function(colName, ordered, onserver, dbname) {
           writeConcern: {w: 1}
         };
       }
-      self._currCmd.updates.push({q: query, u: updObj, multi: multi, upsert: false});
+      self._currCmd.updates.push({q: query, u: updObj, multi: multi, upsert: upsert});
+    };
+
+    findobj.upsert = function(){
+      return upsert = true, findobj;
     };
 
     findobj.remove = function() {


### PR DESCRIPTION
Add upsert() method for Bulk.find to allow the insertion of new documents when there are no matches with the update and updateOne methods.